### PR TITLE
Ensure bundler version matches lockfile

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
+          bundler: '2.7.1'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages


### PR DESCRIPTION
## Summary
- pin the ruby/setup-ruby action to install Bundler 2.7.1 so it matches the lockfile

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cdbc87d53c8321a92a3e1e9c553b02